### PR TITLE
[PFST-2012] Change default log timestamp format to ISO8601

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -48,7 +48,7 @@ func TestDifferentPriorities(t *testing.T) {
 	}
 
 	for i, p := range Priorities() {
-		expected := " " + p.String() + ": file_test: Hey, listen..."
+		expected := " " + p.ShortString() + ": file_test: Hey, listen..."
 		if !strings.HasSuffix(loglines[i], expected) {
 			t.Errorf("Unexpected log line.\nExpected: <date>%s\nBut was: %s", expected, loglines[i])
 		}

--- a/golog.go
+++ b/golog.go
@@ -91,6 +91,30 @@ func (p Priority) String() string {
 	return "UNKNOWN(" + strconv.Itoa(int(p)) + ")"
 }
 
+func (p Priority) ShortString() string {
+	switch p {
+	case LOG_EMERG:
+		return "EMERG"
+	case LOG_ALERT:
+		return "ALERT"
+	case LOG_CRIT:
+		return "CRTCL"
+	case LOG_ERR:
+		return "ERROR"
+	case LOG_WARNING:
+		return "WARN "
+	case LOG_NOTICE:
+		return "NTICE"
+	case LOG_INFO:
+		return "INFO "
+	case LOG_DEBUG:
+		return "DEBUG"
+	case log_DISABLE:
+		return "DSBLD"
+	}
+	return "UNKNOWN(" + strconv.Itoa(int(p)) + ")"
+}
+
 func ParsePriority(p string) Priority {
 	p = strings.ToUpper(p)
 	switch {


### PR DESCRIPTION
Improve performance by using string buffer vs string concatenation